### PR TITLE
去除复制弹出的CMD窗口

### DIFF
--- a/ColorS.py
+++ b/ColorS.py
@@ -4,6 +4,9 @@ import re
 from PIL import Image
 from Picker import ColorsPicker
 from wox import Wox, WoxAPI
+# copy suportting, require `pywin32` package
+import win32clipboard as w
+import win32con as wc
 
 class ColorsViewer(Wox):
 
@@ -550,8 +553,10 @@ class ColorsViewer(Wox):
             return result
 
     def copy_colorHex(self, colorHex):
-        command = 'echo ' + colorHex.strip() + '| clip'
-        os.system(command)
+        w.OpenClipboard()
+        w.EmptyClipboard()
+        w.SetClipboardData(wc.CF_UNICODETEXT,colorHex.strip())
+        w.CloseClipboard()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
在Win8.1 Wox1.3.524 下使用`Enter`复制时弹出ＣＭＤ窗口，通过修改`copy_colorHex`直接调用复制，但需要用户有[`pywin32`](https://pypi.org/project/pywin32/)库（或在插件包中附带）。